### PR TITLE
Renamed Basecamp OAuth configs and refactored some code

### DIFF
--- a/lib/basecamp.rb
+++ b/lib/basecamp.rb
@@ -47,7 +47,7 @@ module Basecamp
   end
 
   def self.read_token(token_key)
-    return tokens[token_key] if tokens.key? token_key
+    return @@tokens[token_key] if @@tokens.key? token_key
 
     token = File.open(token_key, &:readline)
     @@tokens[token_key] = token

--- a/lib/basecamp.rb
+++ b/lib/basecamp.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rack/oauth2'
+
+module Basecamp
+  CLIENT_ID = ENV['BC_CLIENT_ID']
+  CLIENT_SECRET = ENV['BC_CLIENT_SECRET']
+  REDIRECT_URI = ENV['BC_REDIRECT_URI']
+
+  @@tokens = {}
+
+  def self.configure_oauth_client
+    Rack::OAuth2::Client.new(
+      identifier: CLIENT_ID,
+      secret: CLIENT_SECRET,
+      redirect_uri: REDIRECT_URI,
+      authorization_endpoint: 'https://launchpad.37signals.com/authorization/new',
+      token_endpoint: 'https://launchpad.37signals.com/authorization/token'
+    )
+  end
+
+  def self.update_tokens(access_token, refresh_token)
+    update_token('bc_access_token', access_token)
+    update_token('bc_refresh_token', refresh_token)
+  end
+
+  def self.access_token
+    read_token 'bc_access_token'
+  end
+
+  def self.refresh_token
+    read_token 'bc_refresh_token'
+  end
+
+  def self.access_token!(auth_code)
+    client = configure_oauth_client
+    client.authorization_code = auth_code
+
+    # Passing secrets as query string
+    client.access_token!(
+      client_auth_method: nil,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      type: :web_server,
+      code: auth_code
+    )
+  end
+
+  def self.read_token(token_key)
+    return tokens[token_key] if tokens.key? token_key
+
+    token = File.open(token_key, &:readline)
+    @@tokens[token_key] = token
+  end
+
+  def self.update_token(token_key, token)
+    # Writes to file
+    File.open(token_key, 'w') { |f| f.write token }
+    # Saves in memory
+    @@tokens[token_key] = token
+  end
+end

--- a/server.rb
+++ b/server.rb
@@ -1,68 +1,35 @@
+# frozen_string_literal: true
+
 require 'sinatra'
-require 'rack/oauth2'
 require 'httpclient'
+require './lib/basecamp'
 
 configure do
   set :server, :puma
-
-  set :client_id, ENV['CLIENT_ID']
-  set :client_secret, ENV['CLIENT_SECRET']
-  set :redirect_uri, ENV['REDIRECT_URI']
-
 end
 
-def init_basecamp_client
-  Rack::OAuth2::Client.new(
-    identifier: settings.client_id,
-    secret: settings.client_secret,
-    redirect_uri: settings.redirect_uri,
-    authorization_endpoint: 'https://launchpad.37signals.com/authorization/new',
-    token_endpoint: 'https://launchpad.37signals.com/authorization/token'
-  )
+get '/' do
+  'Welcome'
 end
 
-get "/" do
-  "Welcome"
-end
+get '/basecamp/oauth' do
+  client = Basecamp.configure_oauth_client
 
-get "/oauth" do
-  Rack::OAuth2.debug!
-  Rack::OAuth2.logger = logger
-
-  client = init_basecamp_client
-
-  logger.info "Client ID: #{settings.client_id}"
-  logger.info "Client Secret: #{settings.client_secret}"
-  logger.info "Redirect URI: #{settings.redirect_uri}"
-  
   authz_uri = client.authorization_uri type: :web_server
+  logger.info "Redirecting to #{authz_uri}"
 
   `open "#{authz_uri}"`
 end
 
-get "/oauth/callback" do
+get '/basecamp/oauth/callback' do
   # Authorization Response
-  logger.info "Params: #{params}"
-  if not params.key?("code")
-    halt 400
-  end
+  halt 400 unless params.key? :code
 
-  auth_code = params["code"]
-  logger.info "Auth Code: #{auth_code}"
+  auth_code = params[:code]
 
-  client = init_basecamp_client
-  client.authorization_code = auth_code
+  logger.info 'Fetching OAuth tokens from Basecamp'
+  token = Basecamp.access_token! auth_code
 
-  # Passing secrets as query string
-  token = client.access_token!(
-    client_auth_method: nil,
-    client_id: settings.client_id,
-    client_secret: settings.client_secret,
-    type: :web_server,
-    code: auth_code,
-  )
-
-  logger.info "Access Token: #{token.access_token}"
-  logger.info "Refresh Token: #{token.refresh_token}"
-  logger.info "Expires In: #{token.expires_in}"
+  logger.info 'Saving OAuth tokens for further usage'
+  Basecamp.update_tokens(token.access_token, token.refresh_token)
 end


### PR DESCRIPTION
 - Added Basecamp module to encapsulate all Basecamp related logic
 - Renamed `/oauth` -> `/basecamp/oauth`
 - Renamed `/oauth/callback` -> `/basecamp/oauth/basecamp`
 - Used constants in Basecamp module instead of Sinatra settings (`CLIENT_ID`, `CLIENT_SECRET` and `REDIRECT_URI`)
 - Added simple solution to store tokens in disk, the server only needs the `refresh_token` to keep authz "alive"